### PR TITLE
Update for change to the way /click works

### DIFF
--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -157,10 +157,10 @@ end
 function GenMacro(itemID, toyName)
 	-- Did we find the index?  If so, edit that. The macro changes the button to the next stone, but only if we aren't in combat; can't SetAttribute. It then "clicks" the RHTB button
 	if RHTIndex then
-		EditMacro(RHTIndex, " ", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton")
+		EditMacro(RHTIndex, " ", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton 1")
 	else
 		-- No macro found, make a new one, get it's ID, then set the toy on the invisble button. This one is named so people can find it on first use.
-		CreateMacro("RHT", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton")
+		CreateMacro("RHT", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton 1")
 		GetMacroIndex()
 	end
 end


### PR DESCRIPTION
/click was changed in 10.0.2, this fixes the macro to work with it.

Users are going to be stuck with a non-working macro from before 10.0.0. The addon needs something to check for a bad macro and replace it with a new one. I suggest putting something into the `PLAYER_ENTERING_WORLD` event handler that will replace a dud macro with a new good one during login.