### PR TITLE
Make local leaked globals, fix XP bar flicker issue

### DIFF
--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -6,6 +6,7 @@ local RHTIndex = false --Macro index
 RHT = {} --Setup for button and timeout frame
 local RHTInitialized = false
 local macroVersion = 1 -- macro version to know if we need to forcefully update users
+local needsOne = GetCVar("ActionButtonUseKeyDown")
 
 -- Setting up an invisible button named RHTB.  Toys can only be used through a button click, so we need one for the macro to click.
 local frame = CreateFrame("Frame")
@@ -168,10 +169,10 @@ end
 function GenMacro(itemID, toyName)
 	-- Did we find the index?  If so, edit that. The macro changes the button to the next stone, but only if we aren't in combat; can't SetAttribute. It then "clicks" the RHTB button
 	if RHTIndex then
-		EditMacro(RHTIndex, " ", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r#macro version " .. macroVersion .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton 1")
+		EditMacro(RHTIndex, " ", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r#macro version " .. macroVersion .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton" .. (needsOne == "1" and " 1" or ""))
 	else
 		-- No macro found, make a new one, get it's ID, then set the toy on the invisble button. This one is named so people can find it on first use.
-		CreateMacro("RHT", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r#macro version " .. macroVersion .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton 1")
+		CreateMacro("RHT", "INV_MISC_QUESTIONMARK", "#showtooltip item:" .. itemID .. "\r#macro version " .. macroVersion .. "\r/run if not InCombatLockdown() then RHT.b:SetAttribute(\"item\",\"" .. toyName .. "\") end\r/click RHTB LeftButton" .. (needsOne == "1" and " 1" or ""))
 		GetMacroIndex()
 	end
 end

--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -23,24 +23,18 @@ RHT.b = CreateFrame("Button","RHTB",nil,"SecureActionButtonTemplate")
 RHT.b:SetAttribute("type","item")
 -- Setting up a frame to wait and see if the toybox is loaded before getting stones on login.
 local timeOut = 10 --Delay for checking stones.
-RHT.to = CreateFrame("Frame","RHTO", UIParent)
-RHT.to:SetScript("OnUpdate", function (self, elapse)
-	if timeOut > 0 then
-		timeOut = timeOut - elapse
-	else
-		if C_ToyBox.GetNumToys() > 0 then
-			GetLearnedStones()
-			if RHTInitialized then
-				SetRandomHearthToy()
-				--print "RHT initialized" -- uncomment for debugging future versions
-				RHT.to:SetScript("OnUpdate", nil)
-			else
-				timeOut = 1
-			end
-		else
-			timeOut = 1
-		end
-	end
+C_Timer.After(timeOut, function()
+    local ticker
+    ticker = C_Timer.NewTicker(1, function()
+  		if C_ToyBox.GetNumToys() > 0 then
+  			GetLearnedStones()
+  			if RHTInitialized then
+  				SetRandomHearthToy()
+  				--print "RHT initialized" -- uncomment for debugging future versions
+  				ticker:Cancel()
+  			end
+  		end
+    end)
 end)
 
 frame:RegisterEvent("PLAYER_ENTERING_WORLD")
@@ -113,22 +107,15 @@ function SetRandomHearthToy()
 end
 
 -- Get stones learned and usable by character
-local ToyCollSetting
-local ToyUnCollSetting
-local ToyUsableSetting
 function GetLearnedStones()
 	-- Get the current setting for the toybox so we can set it back after we're done.
-	if not (ToyCollSetting and ToyUnCollSetting and ToyUsableSetting) then
-        ToyCollSetting = C_ToyBox.GetCollectedShown()
-        ToyUnCollSetting = C_ToyBox.GetUncollectedShown()
-        ToyUsableSetting = C_ToyBox.GetUnusableShown()
-    end
+    local ToyCollSetting = C_ToyBox.GetCollectedShown()
+    local ToyUnCollSetting = C_ToyBox.GetUncollectedShown()
+    local ToyUsableSetting = C_ToyBox.GetUnusableShown()
 	
 	C_ToyBox.SetCollectedShown(true) -- List collected toys
 	C_ToyBox.SetUncollectedShown(false) -- Don't list uncollected toys
 	C_ToyBox.SetUnusableShown(false) -- Don't list unusable toys in the the collection.
-    
-    	
 	
 	-- Go through all the toys to find the usable stons.
 	for i = 1, C_ToyBox.GetNumFilteredToys() do
@@ -140,14 +127,11 @@ function GetLearnedStones()
 		end
 	end
 	
-	if next(UsableHearthToyIndex) then
-        -- Reset the toybox filter
-    	C_ToyBox.SetCollectedShown(ToyCollSetting)
-    	C_ToyBox.SetUncollectedShown(ToyUnCollSetting)
-    	C_ToyBox.SetUnusableShown(ToyUsableSetting)
-        ToyCollSetting = nil
-        ToyUnCollSetting = nil
-        ToyUsableSetting = nil
+	-- Reset the toybox filter
+    C_ToyBox.SetCollectedShown(ToyCollSetting)
+    C_ToyBox.SetUncollectedShown(ToyUnCollSetting)
+    C_ToyBox.SetUnusableShown(ToyUsableSetting)
+    if next(UsableHearthToyIndex) then
 		RHTInitialized = true
 	end
 end

--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -8,6 +8,15 @@ local RHTInitialized = false
 local macroVersion = 1 -- macro version to know if we need to forcefully update users
 local needsOne = GetCVar("ActionButtonUseKeyDown")
 
+local SetRandomHearthToy
+local GetLearnedStones
+local GetMacroIndex
+local CheckMacroIndex
+local GenMacro
+local RemoveStone
+local SpellcastUpdate
+local RandomKey
+
 -- Setting up an invisible button named RHTB.  Toys can only be used through a button click, so we need one for the macro to click.
 local frame = CreateFrame("Frame")
 RHT.b = CreateFrame("Button","RHTB",nil,"SecureActionButtonTemplate")
@@ -81,7 +90,7 @@ AllHearthToyIndex[200630] = 391042 --Ohn'ir Windsage's Hearthstone
 -- This is the meat right here.
 function SetRandomHearthToy()
 	-- Setting the new stone while in combat is bad.
-	--if not InCombatLockdown() then
+	if not InCombatLockdown() then
 		-- Find the macro.
 		CheckMacroIndex()
 		-- Rebuild the stone list if it's empty.
@@ -100,19 +109,26 @@ function SetRandomHearthToy()
 			-- Set button for first use
 			if not RHT.b:GetAttribute("item") then RHT.b:SetAttribute("item",toyName) end
 		end
-	--end
+	end
 end
 
 -- Get stones learned and usable by character
+local ToyCollSetting
+local ToyUnCollSetting
+local ToyUsableSetting
 function GetLearnedStones()
 	-- Get the current setting for the toybox so we can set it back after we're done.
-	local ToyCollSetting = C_ToyBox.GetCollectedShown()
-	local ToyUnCollSetting = C_ToyBox.GetUncollectedShown()
-	local ToyUsableSetting = C_ToyBox.GetUnusableShown()
+	if not (ToyCollSetting and ToyUnCollSetting and ToyUsableSetting) then
+        ToyCollSetting = C_ToyBox.GetCollectedShown()
+        ToyUnCollSetting = C_ToyBox.GetUncollectedShown()
+        ToyUsableSetting = C_ToyBox.GetUnusableShown()
+    end
 	
 	C_ToyBox.SetCollectedShown(true) -- List collected toys
 	C_ToyBox.SetUncollectedShown(false) -- Don't list uncollected toys
-	C_ToyBox.SetUnusableShown(false) -- Don't list unusable toys in the the collection.	
+	C_ToyBox.SetUnusableShown(false) -- Don't list unusable toys in the the collection.
+    
+    	
 	
 	-- Go through all the toys to find the usable stons.
 	for i = 1, C_ToyBox.GetNumFilteredToys() do
@@ -123,11 +139,15 @@ function GetLearnedStones()
 			end
 		end
 	end
-	 -- Reset the toybox filter
-	C_ToyBox.SetCollectedShown(ToyCollSetting)
-	C_ToyBox.SetUncollectedShown(ToyUnCollSetting)
-	C_ToyBox.SetUnusableShown(ToyUsableSetting)
+	
 	if next(UsableHearthToyIndex) then
+        -- Reset the toybox filter
+    	C_ToyBox.SetCollectedShown(ToyCollSetting)
+    	C_ToyBox.SetUncollectedShown(ToyUnCollSetting)
+    	C_ToyBox.SetUnusableShown(ToyUsableSetting)
+        ToyCollSetting = nil
+        ToyUnCollSetting = nil
+        ToyUsableSetting = nil
 		RHTInitialized = true
 	end
 end

--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -202,6 +202,7 @@ function RandomKey(t)
     for key, value in pairs(t) do
         keys[#keys+1] = key --Store keys in another table.
     end
+    if (not #keys) or (#keys < 1) then return 0 end
     index = keys[math.random(1, #keys)]
     return index
 end

--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -106,9 +106,9 @@ end
 -- Get stones learned and usable by character
 function GetLearnedStones()
 	-- Get the current setting for the toybox so we can set it back after we're done.
-	ToyCollSetting = C_ToyBox.GetCollectedShown()
-	ToyUnCollSetting = C_ToyBox.GetUncollectedShown()
-	ToyUsableSetting = C_ToyBox.GetUnusableShown()
+	local ToyCollSetting = C_ToyBox.GetCollectedShown()
+	local ToyUnCollSetting = C_ToyBox.GetUncollectedShown()
+	local ToyUsableSetting = C_ToyBox.GetUnusableShown()
 	
 	C_ToyBox.SetCollectedShown(true) -- List collected toys
 	C_ToyBox.SetUncollectedShown(false) -- Don't list uncollected toys

--- a/RandomHearthToy.toc
+++ b/RandomHearthToy.toc
@@ -1,6 +1,6 @@
 ## Interface: 100002
 ## Title: Random Hearth Toy Continued
 ## Author: awls99
-## Version: 1.1.0
+## Version: 1.1.1
 
 RandomHearthToy.lua


### PR DESCRIPTION
So I've found this addon is causing the XP and Reputation bars to flicker, while RHT is trying to initialize. During setup, RHT will clear existing toybox filters, look for hearthstones, then reset the existing toybox filters.

Every time it changes the toybox filters, the XP and Reputation bars flicker. I don't know why, I certainly don't see any connection. Probably a bug on Blizzards end.

The problem is, if any of these situations happens:
1. The player has no Hearthstones, or
2. The local game hasn't cached data about hearthstone toys yet, or
3. The player has Expansion/Source filters setup that filter out all their hearthstones,

then RHT keeps trying over and over every second, checking the toybox again and again. This causes the XP and Rep bars to keep flickering every second until the toybox finally works, which probably won't happen until the player opens their toybox and resets all the filters.

The change I've made here is to not reset back to the player's original filters if a hearthstone is not found.