### PR TITLE
Stone of Hearth spell id fix

### DIFF
--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -26,6 +26,8 @@ AllHearthToyIndex[206195] = { spellId = 412555, name = "Path of the Naaru" }
 AllHearthToyIndex[209035] = { spellId = 422284, name = "Hearthstone of the Flame" }
 AllHearthToyIndex[208704] = { spellId = 420418, name = "Deepdweller's Earthen Hearthstone" }
 AllHearthToyIndex[212337] = { spellId = 401802, name = "Stone of the Hearth" }
+AllHearthToyIndex[212337] = { spellId = 431644, name = "Stone of the Hearth" }
+
 
 
 -- Ensure Ace3 is loaded

--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -25,7 +25,7 @@ AllHearthToyIndex[200630] = { spellId = 391042, name = "Ohn'ir Windsage's Hearth
 AllHearthToyIndex[206195] = { spellId = 412555, name = "Path of the Naaru" }
 AllHearthToyIndex[209035] = { spellId = 422284, name = "Hearthstone of the Flame" }
 AllHearthToyIndex[208704] = { spellId = 420418, name = "Deepdweller's Earthen Hearthstone" }
-AllHearthToyIndex[212337] = { spellId = 431644, name = "Stone of the Hearth" }
+AllHearthToyIndex[212337] = { spellId = 401802, name = "Stone of the Hearth" }
 
 
 -- Ensure Ace3 is loaded

--- a/RandomHearthToy.toc
+++ b/RandomHearthToy.toc
@@ -1,7 +1,7 @@
 ## Interface: 100205
 ## Title: Random Hearth Toy Continued
 ## Author: awls99
-## Version: 2.0.2
+## Version: 2.0.3
 ## OptionalDeps: Ace3, LibStub
 
 ## SavedVariables: RandomHearthToyDB


### PR DESCRIPTION
I think blizz fucked up the spell on Stone of Hearth, according to wowhead it links to default hs spell :|