### PR TITLE
fix #53: Call registerOptions before SetRandomHearthToy on initializa…

### DIFF
--- a/RandomHearthToy.lua
+++ b/RandomHearthToy.lua
@@ -99,8 +99,8 @@ C_Timer.After(timeOut, function()
 		if C_ToyBox.GetNumToys() > 0 then
 			GetLearnedStones()
 			if RHTInitialized then
-				SetRandomHearthToy()
 				registerOptions()
+				SetRandomHearthToy()
 				ticker:Cancel()
 			end
 		end


### PR DESCRIPTION
This pull request makes a minor adjustment to the initialization sequence in `RandomHearthToy.lua`, specifically changing the order in which `registerOptions()` and `SetRandomHearthToy()` are called after verifying initialization.

- The call to `registerOptions()` now occurs before `SetRandomHearthToy()` within the initialization logic, ensuring options are registered prior to setting the random hearth toy.
- This fixes #53 which was caused by options not being respected during initialization.